### PR TITLE
Clear when modal pops up. 

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -102,6 +102,16 @@ $(document).ready(function(){
   });
 });
 
+//Clears Quotes generated when the modal is open.
+$(document).ready(function(){
+  $(cancelBtn).click(function(){
+  $("#og-Quote").empty();
+  $("#og-author").empty();
+  $("#tr-author").empty();
+  $("#tr-Quote").empty();
+  });
+});
+
 formLanguage.addEventListener("submit", gotoTranslated);
 cancelBtn.addEventListener("click", hideme)
 searchAgainBtn.addEventListener("click", clear)


### PR DESCRIPTION
When modal pops up fetch is still run, but on, cancel it clears any quotes/translation from the fetch